### PR TITLE
fix bug add dumpsimplestats option to select proper evaluator

### DIFF
--- a/qilin.core/src/qilin/CoreConfig.java
+++ b/qilin.core/src/qilin/CoreConfig.java
@@ -157,6 +157,12 @@ public class CoreConfig {
          * if true, dump stats into files.
          */
         public boolean dumpStats = false;
+
+
+        /**
+         * if true, dump stats into files without Csv files.
+         */
+        public boolean dumpSimpleStats = false;
     }
 
     protected CorePTAConfiguration ptaConfig;

--- a/qilin.core/src/qilin/stat/Exporter.java
+++ b/qilin.core/src/qilin/stat/Exporter.java
@@ -290,7 +290,7 @@ public class Exporter {
 
     public String report() {
         String tmp = report.toString();
-        if (CoreConfig.v().getOutConfig().dumpStats) {
+        if (CoreConfig.v().getOutConfig().dumpStats || CoreConfig.v().getOutConfig().dumpSimpleStats) {
             String statistics = "Statistics.txt";
             String finalPath = getFilePath(statistics);
             Util.writeToFile(finalPath, tmp);

--- a/qilin.pta/src/driver/PTAOption.java
+++ b/qilin.pta/src/driver/PTAOption.java
@@ -74,6 +74,7 @@ public class PTAOption extends Options {
         addOption("cg", "dumpcallgraph", "Output .dot callgraph file (default value: false)");
         addOption("jimple", "dumpjimple", "Dump appclasses to jimple. (default value: false)");
         addOption("stats", "dumpstats", "Dump statistics into files. (default value: false)");
+        addOption("simplestats", "dumpsimplestats", "Dump statistics into files without csv files. (default value: false)");
         addOption("ptsall", "dumpallpts",
                 "Dump points-to of lib vars results to output/pts.txt (default value: false)");
         addOption("pag", "dumppag", "Print PAG to terminal. (default value: false)");
@@ -210,6 +211,9 @@ public class PTAOption extends Options {
         }
         if (cmd.hasOption("dumpstats")) {
             PTAConfig.v().getOutConfig().dumpStats = true;
+        }
+        if (cmd.hasOption("dumpsimplestats")) {
+            PTAConfig.v().getOutConfig().dumpSimpleStats = true;
         }
     }
 

--- a/qilin.pta/src/qilin/pta/tools/BasePTA.java
+++ b/qilin.pta/src/qilin/pta/tools/BasePTA.java
@@ -24,7 +24,9 @@ import qilin.core.builder.CallGraphBuilder;
 import qilin.core.pag.PAG;
 import qilin.core.solver.Propagator;
 import qilin.core.solver.Solver;
+import qilin.pta.PTAConfig;
 import qilin.stat.IEvaluator;
+import qilin.stat.PTAEvaluator;
 import qilin.stat.SimplifiedEvaluator;
 import qilin.util.PTAUtils;
 
@@ -32,8 +34,10 @@ public abstract class BasePTA extends CorePTA {
     protected IEvaluator evaluator;
 
     public BasePTA() {
-//        this.evaluator = new PTAEvaluator(this);
         this.evaluator = new SimplifiedEvaluator(this);
+        if (PTAConfig.v().getOutConfig().dumpStats) {
+            this.evaluator = new PTAEvaluator(this);
+        }
     }
 
     public IEvaluator evaluator() {


### PR DESCRIPTION
To fix the issue#12 : Cannot Generate Static CSV Tables When Enabling -stats Option for the Simple Example.
fix bug add dumpsimplestats option to select proper evaluator