### PR TITLE
Replace deprecated commons-cli APIs (GnuParser/OptionBuilder) in PTAOption

### DIFF
--- a/qilin.pta/src/driver/PTAOption.java
+++ b/qilin.pta/src/driver/PTAOption.java
@@ -19,10 +19,9 @@
 package driver;
 
 import org.apache.commons.cli.CommandLine;
-import org.apache.commons.cli.GnuParser;
+import org.apache.commons.cli.DefaultParser;
 import org.apache.commons.cli.HelpFormatter;
 import org.apache.commons.cli.Option;
-import org.apache.commons.cli.OptionBuilder;
 import org.apache.commons.cli.Options;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -41,18 +40,22 @@ public class PTAOption extends Options {
      * add option "-brief -option" with description
      */
     protected void addOption(String brief, String option, String description) {
-        addOption(new Option(brief, option, false, description));
+        addOption(Option.builder(brief)
+                .longOpt(option)
+                .desc(description)
+                .build());
     }
 
     /**
      * add option "-brief -option <arg>" with description
      */
     protected void addOption(String brief, String option, String arg, String description) {
-        OptionBuilder.withLongOpt(option);
-        OptionBuilder.withArgName(arg);
-        OptionBuilder.hasArg();
-        OptionBuilder.withDescription(description);
-        addOption(OptionBuilder.create(brief));
+        addOption(Option.builder(brief)
+                .longOpt(option)
+                .argName(arg)
+                .hasArg()
+                .desc(description)
+                .build());
     }
 
     public PTAOption() {
@@ -109,7 +112,7 @@ public class PTAOption extends Options {
 
     public void parseCommandLine(String[] args) {
         try {
-            CommandLine cmd = new GnuParser().parse(this, args);
+            CommandLine cmd = new DefaultParser().parse(this, args);
             if (cmd.hasOption("help")) {
                 new HelpFormatter().printHelp("qilin", this);
                 System.exit(0);


### PR DESCRIPTION
## What
`driver.PTAOption` (in `qilin.pta`) uses the deprecated `GnuParser` and `OptionBuilder` from Apache Commons CLI. The project already depends on commons-cli 1.7.0, so this migrates them to the current API.

## Changes (single file: `qilin.pta/src/driver/PTAOption.java`)
- `GnuParser` -> `DefaultParser`
- `OptionBuilder.withLongOpt/withArgName/hasArg/withDescription/create(...)` -> `Option.builder(...)....build()`
- Both `addOption` helpers now use the `Option.builder()` API uniformly

## Behavior
No functional change. The registered options and the `-h` help output are identical (including the long-only options `--includeall`, `--exclude`, `--jre`).

## Testing
Built and tested under JDK 21: `gradle test` (all pass), `gradle fatJar` (builds), and `java -jar ... -h` (output verified unchanged).